### PR TITLE
Add PII filtering and expand activity summary fields

### DIFF
--- a/src/garmin_mcp/sanitize.py
+++ b/src/garmin_mcp/sanitize.py
@@ -1,0 +1,37 @@
+"""Strip personally identifiable information from Garmin API responses."""
+
+from typing import Any
+
+PII_KEYS = frozenset({
+    "ownerId",
+    "ownerFullName",
+    "ownerDisplayName",
+    "ownerProfileImageUrlLarge",
+    "ownerProfileImageUrlMedium",
+    "ownerProfileImageUrlSmall",
+    "userProfilePK",
+    "userProfilePk",
+    "userProfileId",
+    "profileId",
+    "profileNumber",
+    "userPro",
+    "userRoles",
+    "displayName",
+    "fullName",
+    "profileImgNameLarge",
+    "profileImgNameMedium",
+    "profileImgNameSmall",
+    "startLatitude",
+    "startLongitude",
+    "endLatitude",
+    "endLongitude",
+})
+
+
+def strip_pii(data: Any) -> Any:
+    """Recursively remove PII keys from dicts/lists."""
+    if isinstance(data, dict):
+        return {k: strip_pii(v) for k, v in data.items() if k not in PII_KEYS}
+    if isinstance(data, list):
+        return [strip_pii(item) for item in data]
+    return data

--- a/src/garmin_mcp/tools/heart_rate.py
+++ b/src/garmin_mcp/tools/heart_rate.py
@@ -5,6 +5,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp.client import today_str
+from garmin_mcp.sanitize import strip_pii
 
 
 def register(mcp: FastMCP):
@@ -28,10 +29,10 @@ def register(mcp: FastMCP):
         except Exception:
             rhr_data = None
 
-        return {
+        return strip_pii({
             "heart_rates": hr_data,
             "resting_heart_rate": rhr_data,
-        }
+        })
 
     @mcp.tool()
     def get_hrv_data(date: str = "") -> dict[str, Any]:

--- a/src/garmin_mcp/tools/training.py
+++ b/src/garmin_mcp/tools/training.py
@@ -5,6 +5,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp.client import today_str
+from garmin_mcp.sanitize import strip_pii
 
 
 def register(mcp: FastMCP):
@@ -34,7 +35,7 @@ def register(mcp: FastMCP):
 
         client = get_client()
         d = date or today_str()
-        return client.get_training_readiness(d)
+        return strip_pii(client.get_training_readiness(d))
 
     @mcp.tool()
     def get_vo2max_and_fitness(date: str = "") -> dict[str, Any]:
@@ -86,7 +87,7 @@ def register(mcp: FastMCP):
         from garmin_mcp import get_client
 
         client = get_client()
-        return client.get_lactate_threshold(
+        return strip_pii(client.get_lactate_threshold(
             start_date=start_date or None,
             end_date=end_date or None,
-        )
+        ))

--- a/src/garmin_mcp/tools/wellness.py
+++ b/src/garmin_mcp/tools/wellness.py
@@ -6,6 +6,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp.client import today_str
+from garmin_mcp.sanitize import strip_pii
 
 
 def register(mcp: FastMCP):
@@ -21,7 +22,7 @@ def register(mcp: FastMCP):
 
         client = get_client()
         d = date or today_str()
-        return client.get_sleep_data(d)
+        return strip_pii(client.get_sleep_data(d))
 
     @mcp.tool()
     def get_daily_wellness(date: str = "") -> dict[str, Any]:
@@ -59,7 +60,7 @@ def register(mcp: FastMCP):
         except Exception:
             result["respiration"] = None
 
-        return result
+        return strip_pii(result)
 
     @mcp.tool()
     def get_weekly_wellness_summary(

--- a/src/garmin_mcp/tools/workout.py
+++ b/src/garmin_mcp/tools/workout.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
+from garmin_mcp.sanitize import strip_pii
+
 
 def _parse_pace_to_speed(pace_str: str) -> float:
     """Convert pace string (e.g. '4:30' min/km) to speed in m/s."""
@@ -186,12 +188,12 @@ def register(mcp: FastMCP):
             workout.description = description
 
         result = client.upload_running_workout(workout)
-        return {
+        return strip_pii({
             "status": "created",
             "workout_name": name,
             "estimated_duration_seconds": estimated_duration,
             "result": result,
-        }
+        })
 
     @mcp.tool()
     def get_workouts(count: int = 20) -> list[dict[str, Any]]:
@@ -204,4 +206,4 @@ def register(mcp: FastMCP):
 
         client = get_client()
         count = min(count, 100)
-        return client.get_workouts(start=0, limit=count)
+        return strip_pii(client.get_workouts(start=0, limit=count))


### PR DESCRIPTION
## Summary
- Add `sanitize.py` module with `strip_pii()` to recursively remove personally identifiable information (owner names, profile IDs, GPS coordinates) from all Garmin API responses
- Apply PII filtering across 6 tool modules: activities, heart_rate, training, wellness, workout, and splits
- Expand `_summarize_activity` from 18 to 43 fields, adding running dynamics (stride length, ground contact time, vertical oscillation), power metrics, HR zone durations, fastest splits, and temperature data
- Remove hardcoded GPS coordinates (`startLatitude`, `startLongitude`) from activity detail

## Test plan
- [x] Verify `strip_pii()` removes all PII keys from nested API responses
- [x] Confirm all 22 MCP tools return data without PII fields
- [x] Check expanded activity summary includes new running dynamics and HR zone fields
- [x] Validate no regression in existing tool functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)