### PR TITLE
Add trail running support: weather, ClimbPro, GAP, RWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Claude Desktop 등 MCP 클라이언트와 연동하여 러닝 훈련 분석, 계
 
 ## 주요 기능
 
-- **러닝 활동 조회** - 최근 활동, 날짜별 조회, 상세 분석, 스플릿 데이터 (43개 필드: 페이스, 심박, 케이던스, 러닝 다이나믹스, 파워, HR존, 온도 등)
+- **러닝 활동 조회** - 최근 활동, 날짜별 조회, 상세 분석, 스플릿 데이터 (47개 필드: 페이스, 심박, 케이던스, 러닝 다이나믹스, 파워, HR존, GAP, 경사도, 스태미나, 온도 등)
+- **트레일러닝 분석** - ClimbPro 경사 구간 분석, 등급별 난이도, Grade Adjusted Pace, Run/Walk Detection, 날씨 조건
 - **주간/월간 요약** - 볼륨 트렌드, 전월 대비 비교
 - **훈련 지표** - VO2max, 훈련 상태, 훈련 준비도, 레이스 예측, 젖산역치
 - **심박/HRV** - 일간 심박, 심박변이도, 활동별 심박존 분포
@@ -77,16 +78,18 @@ uv run python scripts/auth.py
 | `GARMIN_TOKEN_DIR` | 토큰 저장 경로 | `~/.garminconnect` |
 | `GARMINTOKENS` | Base64 인코딩 토큰 (CI/Docker용) | - |
 
-## 제공 도구 (22개)
+## 제공 도구 (24개)
 
 ### Activities
 
 | 도구 | 설명 | 주요 파라미터 |
 |------|------|--------------|
-| `get_recent_activities` | 최근 러닝 활동 목록 | `count` (기본 20, 최대 100) |
+| `get_recent_activities` | 최근 러닝 활동 목록 (GAP, RWD 포함) | `count` (기본 20, 최대 100) |
 | `get_activities_by_date` | 날짜 범위로 러닝 활동 조회 | `start_date`, `end_date` |
-| `get_activity_detail` | 활동 상세 정보 (GPS 좌표 제외) | `activity_id` |
+| `get_activity_detail` | 활동 상세 정보 (스태미나, 임팩트 로드 포함) | `activity_id` |
 | `get_activity_splits` | km별 스플릿 데이터 | `activity_id` |
+| `get_activity_weather` | 활동 중 날씨 조건 (온도, 습도, 풍속) | `activity_id` |
+| `get_activity_typed_splits` | ClimbPro 경사 구간 분석 (등급, GAP) | `activity_id` |
 
 ### Summary
 
@@ -219,6 +222,8 @@ Claude Desktop에서 다음과 같이 활용할 수 있습니다:
 - "내일 4x1km 인터벌 워크아웃 만들어줘"
 - "내 러닝화 중 교체 시기가 된 것이 있는지 확인해줘"
 - "수면과 훈련 준비도의 상관관계를 분석해줘"
+- "최근 트레일러닝의 경사 구간별 성과를 분석해줘"
+- "트레일러닝에서 걷기/달리기 비율을 확인해줘"
 
 ## 지원하는 러닝 훈련 방법론
 
@@ -229,6 +234,7 @@ Claude Desktop에서 다음과 같이 활용할 수 있습니다:
 | 80/20 Training | 심박존 분포 |
 | Hanson's Method | 주간/월간 볼륨, 페이스 트렌드 |
 | Pfitzinger | 주간 볼륨, 장거리 런 분석 |
+| 트레일/울트라 분석 | ClimbPro 경사 구간, 날씨, RWD, GAP |
 
 ## 개발
 

--- a/src/garmin_mcp/client.py
+++ b/src/garmin_mcp/client.py
@@ -79,6 +79,12 @@ class GarminClient:
     def get_activity_hr_in_timezones(self, activity_id: int) -> list[dict[str, Any]]:
         return self._call("get_activity_hr_in_timezones", activity_id)
 
+    def get_activity_weather(self, activity_id: int) -> dict[str, Any]:
+        return self._call("get_activity_weather", activity_id)
+
+    def get_activity_typed_splits(self, activity_id: int) -> dict[str, Any]:
+        return self._call("get_activity_typed_splits", activity_id)
+
     # --- Training ---
 
     def get_training_status(self, date_str: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Add `get_activity_weather` tool: temperature, humidity, wind speed, weather conditions during activity
- Add `get_activity_typed_splits` tool: ClimbPro climb segments with grade, difficulty rating (DESCENT~HC), and Grade Adjusted Pace (GAP)
- Expand `_summarize_activity` with trail fields: `avg_grade_adjusted_pace` (GAP), `max_vertical_speed`, `water_estimated_ml`, `split_summary` (Run/Walk Detection)
- Expand `get_activity_detail` with: `impact_load`, `begin/end/min_potential_stamina`, plus above trail fields
- Add `get_activity_weather` and `get_activity_typed_splits` client wrapper methods
- Update AGENTS.md with new tool examples, trail running analysis workflow
- Update README.md with new tools and trail running features (22 -> 24 tools)

## Test plan
- [x] `get_activity_weather` returns weather data with location stripped
- [x] `get_activity_typed_splits` returns ClimbPro data with grade, GAP, difficulty
- [x] Trail running activity shows RWD split_summary (run/walk/stand breakdown)
- [x] Road running activity shows trail fields as null/minimal without errors
- [x] All 24 tools register successfully
- [x] Verify via Claude Desktop after reinstall + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)