### PR TITLE
Add wear percentage and max distance to running gear

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -813,7 +813,7 @@ Show my saved workouts
 
 #### `get_running_gear`
 
-Returns running shoes with cumulative distance and activity count. Useful for determining when to replace shoes (typically 500-800 km).
+Returns running shoes with cumulative distance, activity count, user-configured max distance, and wear percentage. Useful for determining when to replace shoes. Returns both active and retired shoes.
 
 **Parameters:** none
 **Returns:** `list[dict]`
@@ -832,27 +832,34 @@ Which of my shoes need replacement?
     "model": "Unknown Shoes",
     "status": "active",
     "date_begin": "2025-05-12T00:00:00.0",
+    "date_end": null,
+    "max_distance_km": 700.0,
     "total_distance_km": 854.96,
-    "total_activities": 95
+    "total_activities": 95,
+    "wear_percentage": 122.1
   },
   {
     "uuid": "469605dc-...",
     "name": "Asics Superblast",
     "status": "active",
+    "max_distance_km": 700.0,
     "total_distance_km": 822.37,
-    "total_activities": 83
+    "total_activities": 83,
+    "wear_percentage": 117.5
   },
   {
     "uuid": "56bcedf9-...",
     "name": "Brooks Glycerin GTS 20",
     "status": "retired",
+    "max_distance_km": 700.0,
     "total_distance_km": 766.04,
-    "total_activities": 84
+    "total_activities": 84,
+    "wear_percentage": 109.4
   }
 ]
 ```
 
-> Shoes with `total_distance_km` > 700 should be flagged for replacement. `status` can be `active` or `retired`.
+> `wear_percentage` is calculated from user-set `max_distance_km` and `total_distance_km`. Values over 100% mean the shoe has exceeded its configured lifespan. `max_distance_km` is `null` if the user hasn't set a distance limit. `status` can be `active` or `retired`. Both active and retired shoes are returned.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ uv run python scripts/auth.py
 
 | 도구 | 설명 | 주요 파라미터 |
 |------|------|--------------|
-| `get_running_gear` | 러닝화 목록 + 누적 거리 | 없음 |
+| `get_running_gear` | 러닝화 목록 + 누적 거리 + 마모율 | 없음 |
 
 ## 워크아웃 생성 가이드
 

--- a/src/garmin_mcp/tools/gear.py
+++ b/src/garmin_mcp/tools/gear.py
@@ -32,15 +32,32 @@ def register(mcp: FastMCP):
                     "date_end": gear.get("dateEnd"),
                 }
 
+                # Max distance limit set by user (meters)
+                max_meters = gear.get("maximumMeters")
+                if max_meters and max_meters > 0:
+                    gear_info["max_distance_km"] = round(max_meters / 1000, 1)
+                else:
+                    gear_info["max_distance_km"] = None
+
                 try:
                     stats = client.get_gear_stats(gear.get("uuid", ""))
+                    total_dist = stats.get("totalDistance", 0)
                     gear_info["total_distance_km"] = round(
-                        stats.get("totalDistance", 0) / 1000, 2
-                    ) if stats.get("totalDistance") else 0
+                        total_dist / 1000, 2
+                    ) if total_dist else 0
                     gear_info["total_activities"] = stats.get("totalActivities", 0)
+
+                    # Wear percentage based on user-set max distance
+                    if max_meters and max_meters > 0 and total_dist:
+                        gear_info["wear_percentage"] = round(
+                            (total_dist / max_meters) * 100, 1
+                        )
+                    else:
+                        gear_info["wear_percentage"] = None
                 except Exception:
                     gear_info["total_distance_km"] = None
                     gear_info["total_activities"] = None
+                    gear_info["wear_percentage"] = None
 
                 running_gear.append(gear_info)
 


### PR DESCRIPTION
## Summary
- `get_running_gear` 도구에 `max_distance_km` (사용자 설정 신발 수명 한계 거리)과 `wear_percentage` (마모율) 필드 추가
- 마모율은 `total_distance / max_distance * 100`으로 계산, 100% 초과 시 교체 필요
- AGENTS.md, README.md 문서 업데이트

## Changes
- `gear.py`: `maximumMeters` 필드 읽어서 `max_distance_km` 변환, `wear_percentage` 계산 로직 추가
- `AGENTS.md`: gear 도구 설명 및 예시 응답에 새 필드 반영
- `README.md`: 도구 설명 업데이트

## Test
```
Total shoes: 24 (Active: 19, Retired: 5)
Shoes over 100% wear:
  Brooks Glycerin GTS 20: 766.04km / 700.0km = 109.4%
  Adidas Adizero Pro 3: 727.76km / 700.0km = 104.0%
  Asics Superblast: 822.37km / 700.0km = 117.5%
  Nike Pegasus Plus: 755.98km / 700.0km = 108.0%
  Adidas Boston 13: 854.96km / 800.0km = 106.9%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)