### PR TITLE
Fix workout conditionType ID mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1060,6 +1060,23 @@ When adding new tools, always verify actual API response keys.
 
 > **Do NOT use `TargetType` enum values from the library.** Our code hardcodes the correct IDs directly. Using library constants will cause targets to be misinterpreted (e.g., heart rate target saved as power, pace target saved as heart rate).
 
+### Garmin workout condition type IDs
+
+**CRITICAL**: The `garminconnect.workout` library `ConditionType` constants are also **WRONG** for several IDs. This was verified by uploading test workouts and re-fetching them from Garmin.
+
+| Purpose | Correct ID | conditionTypeKey | Library says | Library correct? |
+|---------|-----------|-----------------|-------------|-----------------|
+| Lap button | 1 | `lap.button` | DISTANCE = 1 | ❌ |
+| Time | 2 | `time` | TIME = 2 | ✅ |
+| Distance | **3** | `distance` | HEART_RATE = 3 | ❌ |
+| Calories | 4 | `calories` | CALORIES = 4 | ✅ |
+| Power | 5 | `power` | CADENCE = 5 | ❌ |
+| Heart rate | 6 | `heart.rate` | POWER = 6 | ❌ |
+| Iterations | 7 | `iterations` | ITERATIONS = 7 | ✅ |
+| Fixed rest | 8 | `fixed.rest` | (not defined) | - |
+
+> **Do NOT use `ConditionType` enum values from the library.** Our code hardcodes the correct IDs directly. Using `ConditionType.DISTANCE` (=1) will result in `lap.button` instead of distance-based end conditions.
+
 ### Return type pitfalls
 
 Some Garmin APIs return `list` when you might expect `dict`:

--- a/src/garmin_mcp/tools/workout.py
+++ b/src/garmin_mcp/tools/workout.py
@@ -85,15 +85,24 @@ def _build_end_condition(step_def: dict[str, Any]) -> tuple[dict[str, Any], floa
     Supports duration_seconds (time-based) and distance_meters (distance-based).
     Returns (end_condition_dict, end_condition_value).
     """
-    from garminconnect.workout import ConditionType
+    # IMPORTANT: garminconnect library ConditionType constants are WRONG for some IDs.
+    # Actual Garmin API condition type mapping (verified by upload + re-fetch):
+    #   1 = lap.button       (library says DISTANCE - WRONG)
+    #   2 = time             (library says TIME - correct)
+    #   3 = distance         (library says HEART_RATE - WRONG)
+    #   4 = calories         (library says CALORIES - correct)
+    #   5 = power            (library says CADENCE - WRONG)
+    #   6 = heart.rate       (library says POWER - WRONG)
+    #   7 = iterations       (library says ITERATIONS - correct)
+    #   8 = fixed.rest
 
     distance = step_def.get("distance_meters")
     if distance is not None and distance > 0:
         return (
             {
-                "conditionTypeId": ConditionType.DISTANCE,
+                "conditionTypeId": 3,
                 "conditionTypeKey": "distance",
-                "displayOrder": ConditionType.DISTANCE,
+                "displayOrder": 3,
                 "displayable": True,
             },
             float(distance),
@@ -102,9 +111,9 @@ def _build_end_condition(step_def: dict[str, Any]) -> tuple[dict[str, Any], floa
     duration = step_def.get("duration_seconds", 300)
     return (
         {
-            "conditionTypeId": ConditionType.TIME,
+            "conditionTypeId": 2,
             "conditionTypeKey": "time",
-            "displayOrder": ConditionType.TIME,
+            "displayOrder": 2,
             "displayable": True,
         },
         float(duration),
@@ -127,7 +136,6 @@ def _build_steps(steps: list[dict[str, Any]], start_order: int = 1) -> tuple[lis
     """
     from garminconnect.workout import (
         ExecutableStep,
-        TargetType,
         create_repeat_group,
     )
 
@@ -144,9 +152,9 @@ def _build_steps(steps: list[dict[str, Any]], start_order: int = 1) -> tuple[lis
 
             if target_type is None:
                 target_type = {
-                    "workoutTargetTypeId": TargetType.NO_TARGET,
+                    "workoutTargetTypeId": 1,
                     "workoutTargetTypeKey": "no.target",
-                    "displayOrder": TargetType.NO_TARGET,
+                    "displayOrder": 1,
                 }
 
             s = ExecutableStep(


### PR DESCRIPTION
## Summary
- **거리 기반 종료 조건이 `lap.button`으로 잘못 저장되던 버그 수정**
- `garminconnect` 라이브러리의 `ConditionType` 상수도 `TargetType`과 마찬가지로 대부분 실제 Garmin API와 불일치
- 테스트 워크아웃 업로드 후 재조회하여 전체 매핑 검증 완료

### ConditionType 매핑 (검증 완료)

| 용도 | 올바른 ID | conditionTypeKey | 라이브러리 값 | 정확? |
|------|----------|-----------------|-------------|------|
| Lap button | 1 | `lap.button` | DISTANCE = 1 | ❌ |
| Time | 2 | `time` | TIME = 2 | ✅ |
| **Distance** | **3** | `distance` | HEART_RATE = 3 | ❌ |
| Calories | 4 | `calories` | CALORIES = 4 | ✅ |
| Power | 5 | `power` | CADENCE = 5 | ❌ |
| Heart rate | 6 | `heart.rate` | POWER = 6 | ❌ |
| Iterations | 7 | `iterations` | ITERATIONS = 7 | ✅ |
| Fixed rest | 8 | `fixed.rest` | (없음) | - |

### 변경 내역
- `workout.py`: `_build_end_condition()`에서 `ConditionType.DISTANCE`(=1) 대신 올바른 ID 3 사용
- `workout.py`: `TargetType`, `ConditionType` enum import 완전 제거 — 모든 ID를 검증된 값으로 하드코딩
- `AGENTS.md`: ConditionType 매핑 테이블 추가

## Test plan
- [x] 거리 기반 워크아웃 생성 후 재조회하여 `conditionTypeKey: "distance"` 확인
- [x] 심박수 타겟이 `heart.rate.zone`으로 정상 저장 확인
- [x] 시간 기반 종료 조건이 기존과 동일하게 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)