### PR TITLE
Add lap button end condition for workout steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -795,7 +795,7 @@ Create a 4x1km distance-based interval workout at 4:20-4:40/km pace with 2min re
 }
 ```
 
-> Steps support two end conditions: `duration_seconds` (time-based) or `distance_meters` (distance-based). You can mix both in the same workout (e.g., time-based warmup + distance-based intervals).
+> Steps support three end conditions: `duration_seconds` (time-based), `distance_meters` (distance-based), or neither (lap button — press lap to advance). You can mix them in the same workout (e.g., lap-button warmup + distance-based intervals + time-based recovery).
 
 #### `get_workouts`
 
@@ -882,14 +882,15 @@ Detailed reference for the `create_running_workout` `steps` parameter.
 
 ### End conditions (step duration)
 
-Each step (except `repeat`) must have exactly one end condition:
+Each step (except `repeat`) uses one of three end conditions:
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
 | `duration_seconds` | int | Time-based end condition | `"duration_seconds": 300` (5 min) |
 | `distance_meters` | int | Distance-based end condition | `"distance_meters": 1000` (1 km) |
+| _(neither)_ | - | Lap button — press lap to advance | `{"type": "warmup"}` |
 
-If both are provided, `distance_meters` takes priority. You can mix time-based and distance-based steps in the same workout.
+Priority: `distance_meters` > `duration_seconds` > lap button. You can mix all three in the same workout.
 
 ### Target types (optional)
 

--- a/TOOL_SPEC.md
+++ b/TOOL_SPEC.md
@@ -612,8 +612,8 @@ No parameters.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | str | yes | `"warmup"`, `"cooldown"`, `"interval"`, `"recovery"`, `"rest"`, `"repeat"` |
-| `duration_seconds` | int | one of | Time-based end condition |
-| `distance_meters` | int | one of | Distance-based end condition |
+| `duration_seconds` | int | no | Time-based end condition |
+| `distance_meters` | int | no | Distance-based end condition (priority over duration) |
 | `target` | dict | no | Intensity target (see below) |
 | `description` | str | no | Step notes |
 

--- a/src/garmin_mcp/tools/workout.py
+++ b/src/garmin_mcp/tools/workout.py
@@ -108,15 +108,27 @@ def _build_end_condition(step_def: dict[str, Any]) -> tuple[dict[str, Any], floa
             float(distance),
         )
 
-    duration = step_def.get("duration_seconds", 300)
+    duration = step_def.get("duration_seconds")
+    if duration is not None and duration > 0:
+        return (
+            {
+                "conditionTypeId": 2,
+                "conditionTypeKey": "time",
+                "displayOrder": 2,
+                "displayable": True,
+            },
+            float(duration),
+        )
+
+    # No duration or distance specified → lap button (press lap to advance)
     return (
         {
-            "conditionTypeId": 2,
-            "conditionTypeKey": "time",
-            "displayOrder": 2,
+            "conditionTypeId": 1,
+            "conditionTypeKey": "lap.button",
+            "displayOrder": 1,
             "displayable": True,
         },
-        float(duration),
+        0.0,
     )
 
 
@@ -221,7 +233,8 @@ def register(mcp: FastMCP):
         The workout will be synced to your Garmin watch.
 
         Each step has a 'type' (warmup, interval, recovery, rest, cooldown, repeat)
-        and either 'duration_seconds' (time-based) or 'distance_meters' (distance-based).
+        and either 'duration_seconds' (time-based), 'distance_meters' (distance-based),
+        or neither (lap button - press lap to advance to next step).
         Repeat steps have 'count' and nested 'steps'.
         Optionally set a 'target' with type (pace, heart_rate, cadence, power) and min/max values.
         Each step can have a 'description' for notes.


### PR DESCRIPTION
## Summary
- 워크아웃 스텝에서 `duration_seconds`와 `distance_meters` 둘 다 지정하지 않으면 **랩 버튼(lap button)** 종료 조건으로 설정
- 워밍업/쿨다운에서 자유롭게 달리다가 랩 버튼으로 다음 스텝으로 넘어가는 용도로 활용 가능

### 종료 조건 우선순위
| 우선순위 | 조건 | 동작 |
|---------|------|------|
| 1 | `distance_meters` 지정 | 거리 기반 종료 |
| 2 | `duration_seconds` 지정 | 시간 기반 종료 |
| 3 | 둘 다 미지정 | 랩 버튼 (수동 종료) |

### 사용 예시
```json
{"type": "warmup", "description": "Feel-based warmup, press lap when ready"}
{"type": "interval", "distance_meters": 1000, "target": {"type": "pace", "min": "4:20", "max": "4:40"}}
{"type": "cooldown"}
```

## Test plan
- [ ] 랩 버튼 종료 조건 워크아웃 생성 후 Garmin Connect에서 확인
- [ ] 기존 시간/거리 기반 워크아웃이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)